### PR TITLE
fixed typo

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -62,7 +62,7 @@ To start NDN container with custom config file, copy your config file to designa
 ```
 mkdir conf
 cp <path-to-config>/nfd.conf conf/
-docker run -d --rm --name hub1 -v $(pwd)/conf:/cong -e CONFIG=/conf/nfd.conf hub
+docker run -d --rm --name hub1 -v $(pwd)/conf:/conf -e CONFIG=/conf/nfd.conf hub
 ```
 
 ### Saving log to host machine


### PR DESCRIPTION
Been relying on this pretty extensively and it is SUPER cool. It's not finished but I've been modifying the structure so there is a third kind of node. I'm just calling it a broker for now but essentially I wanted to test nodes that could produce and consume. The only way I could get it to work properly was to have the broker nodes `depends_on` on the nfd nodes then register faces/routes to them. I run nfd-autoreg on the nfd nodes with some base prefix I had to make sure matched what was in the consumer and produce env... as opposed to the original routing structure where the faces/route registration pattern follows the docker-compose dependency hierarchy and creates a unidirectional interest path from consumer to producer. Anyway, neither here nor there, just wanted to add some flavor to a very banal PR.